### PR TITLE
Include note contents in search query

### DIFF
--- a/src/renderer/containers/main/search.ts
+++ b/src/renderer/containers/main/search.ts
@@ -27,7 +27,7 @@ class Search extends Container<SearchState, MainCTX> {
 
     return (
       Svelto.Fuzzy.match ( this.ctx.note.getTitle ( note ), query, false ) ||
-      this.ctx.note.getPlainContent ( note ).indexOf(query) > -1
+      this.ctx.note.getPlainContent ( note ).toLowerCase().indexOf(query.toLowerCase()) > -1
     )
   }
 

--- a/src/renderer/containers/main/search.ts
+++ b/src/renderer/containers/main/search.ts
@@ -25,8 +25,10 @@ class Search extends Container<SearchState, MainCTX> {
 
   _isNoteMatch = ( note: NoteObj, query: string ): boolean => {
 
-    return Svelto.Fuzzy.match ( this.ctx.note.getTitle ( note ), query, false );
-
+    return (
+      Svelto.Fuzzy.match ( this.ctx.note.getTitle ( note ), query, false ) ||
+      this.ctx.note.getPlainContent ( note ).indexOf(query) > -1
+    )
   }
 
   _filterNotesByQuery = ( notes: NoteObj[], query: string ): NoteObj[] => {


### PR DESCRIPTION
Solution attempt for https://github.com/fabiospampinato/notable/issues/48

@fabiospampinato Curious to hear your thoughts on this. It works well enough in most cases and doesn't significantly hurt performance. The down-side of using `indexOf` is that you only get an exact, case-sensitive match.