### PR TITLE
Fixes Cyrillic alphabet title bug

### DIFF
--- a/src/renderer/utils/utils.ts
+++ b/src/renderer/utils/utils.ts
@@ -17,7 +17,7 @@ const Utils = {
 
   getFirstUnemptyLine ( str: string ): string | null {
 
-    const match = str.match ( /^.*?\w.*$/m );
+    const match = str.match ( /^.*?[\wа-яА-Я].*$/m );
 
     return match && match[0];
 


### PR DESCRIPTION
Fix for https://github.com/fabiospampinato/notable/issues/73

This should work for all [Cyrillic alphabets](https://en.wikipedia.org/wiki/Cyrillic_alphabets)

TEST:
```javascript
"Заглавие".match ( /^.*?\w.*$/m )
null

"Заглавие".match ( /^.*?[\wа-яА-Я].*$/m )
["Заглавие", index: 0, input: "Заглавие", groups: undefined]

"Title".match ( /^.*?[\wа-яА-Я].*$/m )
["Title", index: 0, input: "Title", groups: undefined]

"hipopótamo maçã pólen ñ poção água língüa".match ( /^.*?[\wа-яА-Я].*$/m )
["hipopótamo maçã pólen ñ poção água língüa", index: 0, input: "hipopótamo maçã pólen ñ poção água língüa", groups: undefined]

```