### PR TITLE
Change line wrapping shortcut due to conflict with polish "ż" letter conflict

### DIFF
--- a/src/renderer/components/main/mainbar/code/index.tsx
+++ b/src/renderer/components/main/mainbar/code/index.tsx
@@ -40,7 +40,7 @@ const options: any = { //TSC
     [`${ALMD}-Ctrl-Up`]: 'swapLineUp',
     [`${ALMD}-Ctrl-Down`]: 'swapLineDown',
     'Alt-LeftClick': Utils.addSelection,
-    'Alt-Z': Utils.toggleWrapping,
+    'Alt-Q': Utils.toggleWrapping,
     [`${CTMD}-Enter`]: Todo.toggleBox,
     'Alt-D': Todo.toggleDone,
     [`${CTMD}-M`]: false,


### PR DESCRIPTION
Polish alphabet letters use an Alt-letter combinations, so Utils.toggleWrapping original shortcut caused conflict. Changed it to Sublime-style Alt-Q. 

Without this Notable won't be usable for Poles. 