### PR TITLE
Export: add export to html

### DIFF
--- a/src/main/windows/main.ts
+++ b/src/main/windows/main.ts
@@ -46,7 +46,7 @@ class Main extends Route {
             type: 'separator'
           },
           {
-            label: 'Export...',
+            label: 'Export HTML',
             enabled: flags && !flags.isMultiEditorEditing,
             click: () => this.win.webContents.send ( 'export' )
           },

--- a/src/main/windows/main.ts
+++ b/src/main/windows/main.ts
@@ -46,6 +46,14 @@ class Main extends Route {
             type: 'separator'
           },
           {
+            label: 'Export...',
+            enabled: flags && !flags.isMultiEditorEditing,
+            click: () => this.win.webContents.send ( 'export' )
+          },
+          {
+            type: 'separator'
+          },
+          {
             label: 'Open Data Directory',
             click: () => this.win.webContents.send ( 'cwd-open-in-app' )
           },

--- a/src/renderer/components/main/extra/ipc.tsx
+++ b/src/renderer/components/main/extra/ipc.tsx
@@ -57,6 +57,7 @@ class IPC extends Component<{ containers: [IMain, ICWD]}, undefined> {
     ipc.on ( 'tag-previous', this.__tagPrevious );
     ipc.on ( 'trash-empty', this.__trashEmpty );
     ipc.on ( 'tutorial-dialog', this.__tutorialDialog );
+    ipc.on ( 'export', this.__export );
 
   }
 
@@ -89,7 +90,7 @@ class IPC extends Component<{ containers: [IMain, ICWD]}, undefined> {
     ipc.removeListener ( 'tag-previous', this.__tagPrevious );
     ipc.removeListener ( 'trash-empty', this.__trashEmpty );
     ipc.removeListener ( 'tutorial-dialog', this.__tutorialDialog );
-
+    ipc.removeListener ( 'export', this.__export );
   }
 
   /* HANDLERS */
@@ -254,6 +255,10 @@ class IPC extends Component<{ containers: [IMain, ICWD]}, undefined> {
 
     this.main.tutorial.dialog ();
 
+  }
+
+  __export = () => {
+    this.cwd.export(this.main.note);
   }
 
 }

--- a/src/renderer/containers/cwd/index.ts
+++ b/src/renderer/containers/cwd/index.ts
@@ -104,41 +104,52 @@ class CWD extends Container<CWDState, CWDCTX> {
   }
 
   export = (note) => {
-    const filepath = remote.dialog.showSaveDialog(remote.getCurrentWindow(), {
+
+    const filepath = remote.dialog.showSaveDialog (remote.getCurrentWindow (), {
       title: 'Export Note',
-      defaultPath: note.getTitle(),
+      defaultPath: note.getTitle (),
       buttonLabel : 'Export',
       filters :[
        {name: 'HTML', extensions: ['html']}
       ]
     });
 
-    let exportContent = '';;
-    const { plainContent } = note.get();    
-    const fileType = filepath.substr(filepath.lastIndexOf('.') + 1).toLowerCase();
-    switch(fileType) {
+    let exportContent = '';
+    const { plainContent } = note.get ();
+    const fileType = filepath.substr ( filepath.lastIndexOf ( '.' ) + 1 ).toLowerCase ();
+
+    switch ( fileType ) {
+
       case 'html':
         const cssList = [
-          'node_modules/primer-markdown/build/build.css', 
-          'node_modules/codemirror/lib/codemirror.css', 
+          'node_modules/primer-markdown/build/build.css',
+          'node_modules/codemirror/lib/codemirror.css',
           'node_modules/codemirror-github-light/lib/codemirror-github-light-theme.css'];
-        const style = cssList.map(css => fs.readFileSync(path.resolve('', css), 'utf8')).join('');
+
+        const style = cssList.map ( css => fs.readFileSync ( path.resolve( '', css ), 'utf8' ) ).join( '' );
+
         exportContent = `
         <head>
           <style>${style}</style>
         </head>
         <div class='markdown-body'>
-          ${Markdown.render(plainContent)}
-        </div>
-        `;
+          ${Markdown.render ( plainContent ) }
+        </div>`;
         break;
+
     }
-    fs.writeFile(filepath, exportContent, err => {
+
+    fs.writeFile ( filepath, exportContent, err => {
+
       if (err) {
-        Dialog.alert(err.message);
+
+        Dialog.alert ( err.message );
         return;
+
       }
-      Dialog.alert('Export file success!');
+
+      Dialog.alert ( 'Export file success!' );
+
     });
   }
 

--- a/src/renderer/containers/cwd/index.ts
+++ b/src/renderer/containers/cwd/index.ts
@@ -13,6 +13,7 @@ import Config from '@common/config';
 import Settings from '@common/settings';
 import Tutorial from '@renderer/containers/main/tutorial';
 import File from '@renderer/utils/file';
+import Markdown from '@renderer/utils/markdown';
 
 /* CWD */
 
@@ -100,6 +101,45 @@ class CWD extends Container<CWDState, CWDCTX> {
 
     return folderPaths[0];
 
+  }
+
+  export = (note) => {
+    const filepath = remote.dialog.showSaveDialog(remote.getCurrentWindow(), {
+      title: 'Export Note',
+      defaultPath: note.getTitle(),
+      buttonLabel : 'Export',
+      filters :[
+       {name: 'HTML', extensions: ['html']}
+      ]
+    });
+
+    let exportContent = '';;
+    const { plainContent } = note.get();    
+    const fileType = filepath.substr(filepath.lastIndexOf('.') + 1).toLowerCase();
+    switch(fileType) {
+      case 'html':
+        const cssList = [
+          'node_modules/primer-markdown/build/build.css', 
+          'node_modules/codemirror/lib/codemirror.css', 
+          'node_modules/codemirror-github-light/lib/codemirror-github-light-theme.css'];
+        const style = cssList.map(css => fs.readFileSync(path.resolve('', css), 'utf8')).join('');
+        exportContent = `
+        <head>
+          <style>${style}</style>
+        </head>
+        <div class='markdown-body'>
+          ${Markdown.render(plainContent)}
+        </div>
+        `;
+        break;
+    }
+    fs.writeFile(filepath, exportContent, err => {
+      if (err) {
+        Dialog.alert(err.message);
+        return;
+      }
+      Dialog.alert('Export file success!');
+    });
   }
 
 }


### PR DESCRIPTION
Quick Implement of [#14](https://github.com/fabiospampinato/notable/issues/14), right now just support export to html, but I think if we need to export to pdf or any other datatype, pandoc or anything can do the convert stuff would be better.