### PR TITLE
Add build attention in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ If you have an idea, or you have found a problem, please open an [issue](https:/
 If you want to make a pull request, or fork the app, you should:
 
 ```bash
+# make sure you npm version is at least 5.2.0
 git clone https://github.com/fabiospampinato/notable.git
 cd notable
 npm install


### PR DESCRIPTION
the "npm run iconfont" will run "npx" command which needs the npm version is at least 5.2.0.  I think it would be better to emphasize this point(it also remind me my npm version is too old)