### PR TITLE
Handle "Enter" key press in lists

### DIFF
--- a/src/renderer/components/main/mainbar/code/index.tsx
+++ b/src/renderer/components/main/mainbar/code/index.tsx
@@ -13,12 +13,13 @@ import Utils from './utils';
 const CTMD = is.macOS () ? 'Cmd' : 'Ctrl', // `Cmd` on macOS, `Ctrl` otherwise
       ALMD = is.macOS () ? 'Cmd' : 'Alt'; // `Cmd` on macOS, `Alt` otherwise
 
-const options: any = { //TSC
+export const options: any = { //TSC
   autofocus: true,
   electricChars: false,
   indentUnit: 2,
   indentWithTabs: false,
   lineNumbers: false,
+  lineSeparator: '\n',
   lineWrapping: true,
   mode: 'gfm',
   gitHubSpice: false,
@@ -44,8 +45,10 @@ const options: any = { //TSC
     'Alt-D': Todo.toggleDone,
     [`${CTMD}-M`]: false,
     [`${CTMD}-H`]: false,
-    [`${CTMD}-LeftClick`]: false
-  }
+    [`${CTMD}-LeftClick`]: false,
+    'Enter': Utils.onEnterPressed
+  }, 
+  enterAutoListIntent: true
 };
 
 /* CODE */

--- a/src/renderer/components/main/mainbar/code/utils.ts
+++ b/src/renderer/components/main/mainbar/code/utils.ts
@@ -24,38 +24,63 @@ const Utils = {
 
   },
 
-  async onEnterPressed (cm) {
-    
-    // Get the setting
-    const enabled = Settings.get( 'enterAutoListIntent' );
+  onEnterPressed (cm) {
 
-    // TODO: This doesn't work :( 
-    // If not enabled, don't do anything.    
-    if (!enabled)
+    if (!options.enterAutoListIntent) {
+      cm.execCommand("newlineAndIndent");
       return;
+    }
 
-    // Check if we currently are in a list. 
-    const unorderdSym : string  = "- ";
-    const lineNr : number = cm.getCursor().line;
-    let line : string = cm.getLine(lineNr); // minus one because we moved to the next line already.
+    const unorderedPattern : RegExp = ( options.indentWithTabs ) ? /(\t+)?- / : /(\s+)?- /,
+          orderedPattern : RegExp   = ( options.indentWithTabs ) ? /(\t+)?\d+. / : /(\s+)?\d+. /,
+          lineNr : number           = cm.getCursor().line,
+          line   : string           = cm.getLine(lineNr);
 
+    if (line.match(unorderedPattern)) {
+      
+      // Unordered list
+      const matches = unorderedPattern.exec( line );
+      if (matches === null)
+        return;
+      
+      Utils.handleListEnter(cm, line, lineNr, matches[0], "- ");
 
-    // TODO: When I press enter and the line hasn't changed, 
-    // I should I should undo the indent
-    // This failes when no content is given because of the trim
-    if (line.trim().startsWith(unorderdSym)) {
-      // this makes sure the enter actually works.
-      // I think there should be a way to do the default, but I don't know how.
-      await cm.execCommand("newlineAndIndent");
-      // cm.replaceRange(unorderdSym, {line: lineNr + 1, ch: line.length});
-      Utils.replace(cm, lineNr + 1, unorderdSym, line.length);
-    } else if (line.startsWith(unorderdSym) || line.startsWith(" ".repeat(options.indentUnit) + unorderdSym)) {
-      await cm.execCommand("indentLess");
-      Utils.replace(cm, lineNr, "", 0, line.length);
+    } else if (line.match(orderedPattern)) {
+      
+      // Ordered list
+      const matches = orderedPattern.exec( line );
+      if (matches === null)
+        return;
+
+      let previous : string       = matches[0],
+          previousNumber : number = +( previous.replace( /(^\d+)(.+$)/i,'$1' ) ),
+          next : string           = ( previousNumber + 1 ) + ". ";
+      
+      Utils.handleListEnter( cm, line, lineNr, matches[0], next );
+    
     } else {
-      await cm.execCommand("newlineAndIndent");
+      
+      // Not in a list, so no need to do anything here
+      cm.execCommand( "newlineAndIndent" );
+    
     }
     
+  },
+
+  handleListEnter(cm, line : string, lineNr : number, start : string, next : string) {
+    
+    if ( line.trim() === start.trim() ) {
+
+      cm.execCommand( "indentLess" );
+      Utils.replace( cm, lineNr, "", 0, line.length );
+    
+    } else if ( line.startsWith(start) ) {
+    
+      cm.execCommand( "newlineAndIndent" );
+      Utils.replace( cm, lineNr + 1, next, line.length );
+    
+    }
+
   },
 
   addSelection ( cm, pos ) {


### PR DESCRIPTION
This PR is based on @sebastiendecraene's commits. It fixes the Regexp's used to identify lists, and improves behavior. 

Please note the following:
1. I'm a Java engineer, so I don't really code in JS. If my writing style is not idiomatic or doesn't comply with your coding standards, please feel free to comment, and I will fix it.
2. I'm not yet familiar with the code structure, but I'm not sure that `utils.ts` is the right place for this chunk of code to be in. Should I move it someplace else? (BTW, is there documentation of the code structure anywhere?)

I tested this manually and it seemed to work well.