### PR TITLE
Modify "Change Data Directory" default path to parent directory

### DIFF
--- a/src/renderer/containers/cwd/index.ts
+++ b/src/renderer/containers/cwd/index.ts
@@ -93,7 +93,8 @@ class CWD extends Container<CWDState, CWDCTX> {
     const folderPaths = remote.dialog.showOpenDialog ({
       title: 'Select Data Directory',
       buttonLabel: 'Select',
-      properties: ['openDirectory', 'createDirectory', 'showHiddenFiles']
+      properties: ['openDirectory', 'createDirectory', 'showHiddenFiles'],
+      defaultPath: path.resolve(Config.cwd, '..')
     });
 
     if ( !folderPaths || !folderPaths.length ) return;


### PR DESCRIPTION
For multiple data directories in the same folder:
```
/notes/
├───tutorial
│   ├───attachments
│   └───notes
├───data-dir-1
│   ├───attachments
│   └───notes
└───data-dir-2
    ├───attachments
    └───notes
```
Right now `Change Data Directory...` dialog opens inside the current data directory.
So only `attachments` and `notes` directories are visible by default.
By setting it to one level above we can speed up directory change.
Now dialog shows `tutorial`, `data-dir-1` and `data-dir-2`.