### PR TITLE
Add (toggleable) statusbar widget with word count and position sub-widgets.

### DIFF
--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -123,6 +123,7 @@ type TutorialState = {};
 
 type WindowState = {
   focus: boolean,
+  statusbar: boolean,
   fullscreen: boolean
 };
 

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -65,6 +65,7 @@ type AttachmentsState = {
 };
 
 type EditorState = {
+  statusbar: boolean,
   editing: boolean
 };
 
@@ -123,7 +124,6 @@ type TutorialState = {};
 
 type WindowState = {
   focus: boolean,
-  statusbar: boolean,
   fullscreen: boolean
 };
 

--- a/src/main/windows/main.ts
+++ b/src/main/windows/main.ts
@@ -262,6 +262,11 @@ class Main extends Route {
             accelerator: 'CommandOrControl+Alt+F',
             click: () => this.win.webContents.send ( 'window-focus-toggle' )
           },
+          {
+            label: 'Toggle Statusbar',
+            accelerator: 'CommandOrControl+Alt+.',
+            click: () => this.win.webContents.send ( 'window-statusbar-toggle' )
+          },
           { role: 'togglefullscreen' }
         ]
       },

--- a/src/renderer/components/main/extra/ipc.tsx
+++ b/src/renderer/components/main/extra/ipc.tsx
@@ -34,6 +34,7 @@ class IPC extends Component<{ containers: [IMain, ICWD]}, undefined> {
     ipc.on ( 'cwd-open-in-app', this.__cwdOpenInApp );
     ipc.on ( 'import', this.__import );
     ipc.on ( 'window-focus-toggle', this.__windowFocusToggle );
+    ipc.on ( 'window-statusbar-toggle', this.__windowStatusbarToggle );
     ipc.on ( 'window-fullscreen-set', this.__windowFullscreenSet );
     ipc.on ( 'multi-editor-select-all', this.__multiEditorSelectAll );
     ipc.on ( 'multi-editor-select-invert', this.__multiEditorSelectInvert );
@@ -66,6 +67,7 @@ class IPC extends Component<{ containers: [IMain, ICWD]}, undefined> {
     ipc.removeListener ( 'cwd-open-in-app', this.__cwdOpenInApp );
     ipc.removeListener ( 'import', this.__import );
     ipc.removeListener ( 'window-focus-toggle', this.__windowFocusToggle );
+    ipc.removeListener ( 'window-statusbar-toggle', this.__windowStatusbarToggle );
     ipc.removeListener ( 'window-fullscreen-set', this.__windowFullscreenSet );
     ipc.removeListener ( 'multi-editor-select-all', this.__multiEditorSelectAll );
     ipc.removeListener ( 'multi-editor-select-invert', this.__multiEditorSelectInvert );
@@ -115,6 +117,12 @@ class IPC extends Component<{ containers: [IMain, ICWD]}, undefined> {
   __windowFocusToggle = () => {
 
     this.main.window.toggleFocus ();
+
+  }
+
+  __windowStatusbarToggle = () => {
+
+    this.main.window.toggleStatusbar ();
 
   }
 

--- a/src/renderer/components/main/extra/ipc.tsx
+++ b/src/renderer/components/main/extra/ipc.tsx
@@ -122,7 +122,7 @@ class IPC extends Component<{ containers: [IMain, ICWD]}, undefined> {
 
   __windowStatusbarToggle = () => {
 
-    this.main.window.toggleStatusbar ();
+    this.main.editor.toggleStatusbar ();
 
   }
 

--- a/src/renderer/components/main/mainbar/index.tsx
+++ b/src/renderer/components/main/mainbar/index.tsx
@@ -9,6 +9,7 @@ import PopoverTagsAttachments from '@renderer/components/main/popovers/popover_n
 import Editor from './editor';
 import MultiEditor from './multi_editor';
 import Toolbar from './toolbar';
+import StatusBar from './statusbar';
 
 /* MAINBAR */
 
@@ -22,6 +23,7 @@ const Mainbar = ({ isMultiEditing }) => (
         <PopoverTagsAttachments />
         <Toolbar />
         <Editor />
+        <StatusBar />
       </>
     )}
   </div>

--- a/src/renderer/components/main/mainbar/statusbar.tsx
+++ b/src/renderer/components/main/mainbar/statusbar.tsx
@@ -14,7 +14,7 @@ const Statusbar = ({ isStatusbar }) => {
     return null;
   }
 
-  return <div id="mainbar-statusbar" className="layout-header centerer">
+  return <div id="mainbar-statusbar" className="layout-footer centerer">
     <div className="multiple grow">
       <div className="spacer"></div>
       <Position />
@@ -28,6 +28,6 @@ const Statusbar = ({ isStatusbar }) => {
 export default connect ({
   container: Main,
   selector: ({ container }) => ({
-    isStatusbar: container.window.isStatusbar ()
+    isStatusbar: container.editor.isStatusbar ()
   })
 })( Statusbar );

--- a/src/renderer/components/main/mainbar/statusbar.tsx
+++ b/src/renderer/components/main/mainbar/statusbar.tsx
@@ -1,0 +1,33 @@
+
+/* IMPORT */
+
+import * as React from 'react';
+import {connect} from 'overstated';
+import Main from '@renderer/containers/main';
+import Position from './statusbar_position';
+import WordCount from './statusbar_word_count';
+
+/* STATUSBAR */
+
+const Statusbar = ({ isStatusbar }) => {
+  if (!isStatusbar) {
+    return null;
+  }
+
+  return <div id="mainbar-statusbar" className="layout-header centerer">
+    <div className="multiple grow">
+      <div className="spacer"></div>
+      <Position />
+      <WordCount />
+    </div>
+  </div>
+};
+
+/* EXPORT */
+
+export default connect ({
+  container: Main,
+  selector: ({ container }) => ({
+    isStatusbar: container.window.isStatusbar ()
+  })
+})( Statusbar );

--- a/src/renderer/components/main/mainbar/statusbar_position.tsx
+++ b/src/renderer/components/main/mainbar/statusbar_position.tsx
@@ -1,0 +1,87 @@
+
+/* IMPORT */
+
+import * as React from 'react';
+import {connect} from 'overstated';
+import Main from '@renderer/containers/main';
+
+/* STATUSBAR POSITION */
+
+class Position extends React.PureComponent<any, any> {
+  state = {
+    line: 0,
+    ch: 0,
+    connectedTo: null
+  }
+
+  componentDidMount () {
+    const { isEditing, getCodeMirror } = this.props;
+
+    if (isEditing) {
+      const cm = getCodeMirror(),
+        cursor = cm.getCursor();
+
+      cm.on('cursorActivity', this.onCursorActivity.bind(this));
+
+      this.setState({ line: cursor.line, ch: cursor.ch, connectedTo: cm })
+    }
+  }
+
+  componentDidUpdate () {
+    const { connectedTo } = this.state,
+      { isEditing, getCodeMirror } = this.props;
+
+    if (!connectedTo && isEditing) {
+      const cm = getCodeMirror(),
+        cursor = cm.getCursor();
+
+      cm.on('cursorActivity', this.onCursorActivity.bind(this));
+
+      this.setState({ line: cursor.line, ch: cursor.ch, connectedTo: cm })
+    } else if (!!connectedTo && !isEditing) {
+      connectedTo.off('cursorActivity', this.onCursorActivity.bind(this));
+
+      this.setState({ line: 0, ch: 0, connectedTo: null });
+    }
+  }
+
+  render () {
+    const { line, ch } = this.state;
+
+    return <div className="label" title="Line, Column">{`Ln ${line}, Col ${ch}`}</div>;
+  }
+
+  onCursorActivity () {
+    const { isEditing, getCodeMirror } = this.props;
+
+    if (!isEditing) {
+      return;
+    }
+
+    const cm = getCodeMirror(),
+      cursor = cm.getCursor();
+
+      this.setState({ line: cursor.line, ch: cursor.ch })
+  }
+}
+
+// const Position = ({ isEditing, getCodeMirror }) => {
+//   if (!isEditing) {
+//     return <div className="label" title="Line, Column">Ln 0, Col 0</div>;
+//   }
+
+//   const cm = getCodeMirror(),
+//     cursor = cm.getCursor();
+
+//   return <div className="label" title="Line, Column">{`Ln ${cursor.line}, Col ${cursor.ch}`}</div>;
+// };
+
+/* EXPORT */
+
+export default connect ({
+  container: Main,
+  selector: ({ container }) => ({
+    isEditing: container.editor.isEditing(),
+    getCodeMirror: container.editor.getCodeMirror
+  })
+})( Position );

--- a/src/renderer/components/main/mainbar/statusbar_position.tsx
+++ b/src/renderer/components/main/mainbar/statusbar_position.tsx
@@ -65,17 +65,6 @@ class Position extends React.PureComponent<any, any> {
   }
 }
 
-// const Position = ({ isEditing, getCodeMirror }) => {
-//   if (!isEditing) {
-//     return <div className="label" title="Line, Column">Ln 0, Col 0</div>;
-//   }
-
-//   const cm = getCodeMirror(),
-//     cursor = cm.getCursor();
-
-//   return <div className="label" title="Line, Column">{`Ln ${cursor.line}, Col ${cursor.ch}`}</div>;
-// };
-
 /* EXPORT */
 
 export default connect ({

--- a/src/renderer/components/main/mainbar/statusbar_position.tsx
+++ b/src/renderer/components/main/mainbar/statusbar_position.tsx
@@ -19,7 +19,7 @@ class Position extends React.PureComponent<any, any> {
 
     if (isEditing) {
       const cm = getCodeMirror(),
-        cursor = cm.getCursor();
+            cursor = cm.getCursor();
 
       cm.on('cursorActivity', this.onCursorActivity.bind(this));
 
@@ -29,11 +29,11 @@ class Position extends React.PureComponent<any, any> {
 
   componentDidUpdate () {
     const { connectedTo } = this.state,
-      { isEditing, getCodeMirror } = this.props;
+          { isEditing, getCodeMirror } = this.props;
 
     if (!connectedTo && isEditing) {
       const cm = getCodeMirror(),
-        cursor = cm.getCursor();
+            cursor = cm.getCursor();
 
       cm.on('cursorActivity', this.onCursorActivity.bind(this));
 
@@ -45,12 +45,6 @@ class Position extends React.PureComponent<any, any> {
     }
   }
 
-  render () {
-    const { line, ch } = this.state;
-
-    return <div className="label" title="Line, Column">{`Ln ${line}, Col ${ch}`}</div>;
-  }
-
   onCursorActivity () {
     const { isEditing, getCodeMirror } = this.props;
 
@@ -59,9 +53,15 @@ class Position extends React.PureComponent<any, any> {
     }
 
     const cm = getCodeMirror(),
-      cursor = cm.getCursor();
+          cursor = cm.getCursor();
 
       this.setState({ line: cursor.line, ch: cursor.ch })
+  }
+
+  render () {
+    const { line, ch } = this.state;
+
+    return <div className="label" title="Line, Column">{`Ln ${line}, Col ${ch}`}</div>;
   }
 }
 

--- a/src/renderer/components/main/mainbar/statusbar_word_count.tsx
+++ b/src/renderer/components/main/mainbar/statusbar_word_count.tsx
@@ -1,0 +1,21 @@
+
+/* IMPORT */
+
+import * as React from 'react';
+import {connect} from 'overstated';
+import Main from '@renderer/containers/main';
+
+/* STATUSBAR WORD COUNT */
+
+const WordCount = ({ content }) => {
+  return <div className="label" title="Word Count">{!!content ? content.match(/\S+/g).length : 0}</div>;
+};
+
+/* EXPORT */
+
+export default connect ({
+  container: Main,
+  selector: ({ container }) => ({
+    content: container.note.getPlainContent()
+  })
+})( WordCount );

--- a/src/renderer/containers/main/editor.ts
+++ b/src/renderer/containers/main/editor.ts
@@ -11,6 +11,7 @@ class Editor extends Container<EditorState, MainCTX> {
   /* STATE */
 
   state = {
+    statusbar: false,
     editing: false
   };
 
@@ -133,6 +134,18 @@ class Editor extends Container<EditorState, MainCTX> {
   }
 
   /* API */
+
+  isStatusbar = (): boolean => {
+
+    return this.state.statusbar;
+
+  }
+
+  toggleStatusbar = ( statusbar: boolean = !this.state.statusbar ) => {
+
+    return this.setState ({ statusbar });
+
+  }
 
   isEditing = (): boolean => {
 

--- a/src/renderer/containers/main/window.ts
+++ b/src/renderer/containers/main/window.ts
@@ -12,6 +12,7 @@ class Window extends Container<WindowState, MainCTX> {
 
   state = {
     focus: false,
+    statusbar: false,
     fullscreen: remote.getCurrentWindow ().isFullScreen ()
   };
 
@@ -38,6 +39,18 @@ class Window extends Container<WindowState, MainCTX> {
   toggleFocus = ( focus: boolean = !this.state.focus ) => {
 
     return this.setState ({ focus });
+
+  }
+
+  isStatusbar = (): boolean => {
+
+    return this.state.statusbar;
+
+  }
+
+  toggleStatusbar = ( statusbar: boolean = !this.state.statusbar ) => {
+
+    return this.setState ({ statusbar });
 
   }
 

--- a/src/renderer/containers/main/window.ts
+++ b/src/renderer/containers/main/window.ts
@@ -12,7 +12,6 @@ class Window extends Container<WindowState, MainCTX> {
 
   state = {
     focus: false,
-    statusbar: false,
     fullscreen: remote.getCurrentWindow ().isFullScreen ()
   };
 
@@ -39,18 +38,6 @@ class Window extends Container<WindowState, MainCTX> {
   toggleFocus = ( focus: boolean = !this.state.focus ) => {
 
     return this.setState ({ focus });
-
-  }
-
-  isStatusbar = (): boolean => {
-
-    return this.state.statusbar;
-
-  }
-
-  toggleStatusbar = ( statusbar: boolean = !this.state.statusbar ) => {
-
-    return this.setState ({ statusbar });
 
   }
 

--- a/src/renderer/template/misc.css
+++ b/src/renderer/template/misc.css
@@ -263,12 +263,17 @@
   min-width: 7.5em !important;
 }
 
-.layout .layout-header,
-.layout .layout-footer {
+.layout .layout-header {
   -webkit-app-region: drag;
   height: 38px;
   padding: 0 10px;
   border-bottom: 1px solid transparent;
+}
+
+.layout .layout-footer {
+  height: 38px;
+  padding: 0 10px;
+  border-top: 1px solid transparent;
 }
 
 .layout-header > :not(.multiple):not(.title) {
@@ -294,11 +299,6 @@
 .layout-header .title {
   color: #505050;
   font-size: 13px;
-}
-
-.layout .layout-footer {
-  border-top: 1px solid transparent;
-  border-bottom: none;
 }
 
 .layout .layout-footer.centerer {

--- a/src/renderer/template/misc.css
+++ b/src/renderer/template/misc.css
@@ -192,10 +192,10 @@
   border-left: 1px solid #d8d8d8;
   flex: 4 4 327px;
   min-width: 327px;
-  overflow: hidden;
 }
 
-#mainbar .layout-header {
+#mainbar .layout-header,
+#mainbar .layout-footer {
   background: #f4f4f4;
   border-color: #d8d8d8;
 }
@@ -263,7 +263,8 @@
   min-width: 7.5em !important;
 }
 
-.layout .layout-header {
+.layout .layout-header,
+.layout .layout-footer {
   -webkit-app-region: drag;
   height: 38px;
   padding: 0 10px;
@@ -284,7 +285,8 @@
 
 .layout-header .label,
 .layout-header .button,
-.layout-header .title {
+.layout-header .title,
+.layout-footer .label {
   padding: 2px 7px !important;
   flex-grow: 0;
 }
@@ -292,6 +294,15 @@
 .layout-header .title {
   color: #505050;
   font-size: 13px;
+}
+
+.layout .layout-footer {
+  border-top: 1px solid transparent;
+  border-bottom: none;
+}
+
+.layout .layout-footer.centerer {
+  overflow: hidden;
 }
 
 .layout-content {

--- a/src/renderer/template/misc.css
+++ b/src/renderer/template/misc.css
@@ -263,10 +263,6 @@
   min-width: 7.5em !important;
 }
 
-#mainbar-statusbar .textual {
-  color: rgba(31, 31, 31, 0.65);
-}
-
 .layout .layout-header {
   -webkit-app-region: drag;
   height: 38px;

--- a/src/renderer/template/misc.css
+++ b/src/renderer/template/misc.css
@@ -192,6 +192,7 @@
   border-left: 1px solid #d8d8d8;
   flex: 4 4 327px;
   min-width: 327px;
+  overflow: hidden;
 }
 
 #mainbar .layout-header {
@@ -260,6 +261,10 @@
 #mainbar .multi-editor .tagbox-partial {
   margin: 0 5px 10px !important;
   min-width: 7.5em !important;
+}
+
+#mainbar-statusbar .textual {
+  color: rgba(31, 31, 31, 0.65);
 }
 
 .layout .layout-header {


### PR DESCRIPTION
This PR creates a new statusbar under the primary editor. This statusbar can be used to hold small widgets. The two I've created are word count and "position" (which tracks the current line number and column).

Note: You may want to ensure all of the code works the way you intend, as I haven't work with all of these libs before.