### PR TITLE
Add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -12,3 +12,8 @@ about: Create a report to help us improve
 ### Expected behavior
 
 <!-- Describe what is the expected behavior -->
+
+### Environment
+
+- **OS**: [e.g. Windows 10, Ubuntu 16.04]
+- **Notable version**: [e.g. v1.1.0]

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,14 @@
+---
+name: Bug report
+about: Create a report to help us improve
+---
+
+<!-- Please search existing issues to avoid creating duplicates -->
+
+### Current behavior
+
+<!-- Describe how to reproduce the issue -->
+
+### Expected behavior
+
+<!-- Describe what is the expected behavior -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,14 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+---
+
+<!-- Please search existing issues to avoid creating duplicates -->
+
+### Feature description
+
+<!-- Describe the feature you'd like -->
+
+### Feature motivation
+
+<!-- Why do you want this? -->

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -1,0 +1,6 @@
+---
+name: Question
+about: Ask a question
+---
+
+<!-- Please search existing issues to avoid creating duplicates -->


### PR DESCRIPTION
Add issue templates in order to more easily distinguish issues that are being created, along with asking for relevant information that isn't always posted on the OP, such as Notable version

I searched for several different templates and concluded that GIthub's are the best in my opinion.