### PR TITLE
fix linux appimage icons

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
         "rpm",
         "snap"
       ],
-      "icon": "resources/icon/icon.png",
+      "icon": "resources/icon",
       "category": "Utility"
     },
     "snap": {


### PR DESCRIPTION
In Linux appimage, it generates icons at  `~/.local/share/icons/hicolor/0x0/apps` for my system.
This will let the system failed to show the app icon.
By creating a folder at `~/notable/resources/icon/icons` the appimage will auto-generate all suitable size icons.