### PR TITLE
Use React.memo instead of recompose/pure

### DIFF
--- a/package.json
+++ b/package.json
@@ -162,7 +162,6 @@
     "react-dom": "^16.7.0",
     "react-router-static": "^1.0.0",
     "react-window": "^1.4.0",
-    "recompose": "^0.30.0",
     "remark": "^10.0.1",
     "sha1": "^1.1.1",
     "shallowequal": "^1.1.0",

--- a/src/renderer/components/main/sidebar/tag_group.tsx
+++ b/src/renderer/components/main/sidebar/tag_group.tsx
@@ -3,13 +3,12 @@
 
 import * as _ from 'lodash';
 import * as React from 'react';
-import {pure} from 'recompose';
 import Tags from '@renderer/utils/tags';
 import TagSingle from './tag_single';
 
 /* TAG GROUP */
 
-const TagGroup = pure ( function TagGroup ({ tag, ...props }) {
+const TagGroup: React.FC<any> = React.memo ( function TagGroup ({ tag, ...props }) {
 
   if ( !tag.notes.length ) return null;
 


### PR DESCRIPTION
`React.memo` is introduced since React v16.6.0. `recompose/pure` can be replaced to it.
We should reduce dependence as much as possible. So, I think we should remove (if unnecessary) `recompose`.
***
In the [doc](https://reactjs.org/docs/react-api.html#reactmemo).
> React.memo is a higher order component. It’s similar to React.PureComponent but for function components instead of classes.

