### PR TITLE
Fix devtools duplicate item in menu

### DIFF
--- a/src/main/windows/main.ts
+++ b/src/main/windows/main.ts
@@ -247,10 +247,6 @@ class Main extends Route {
             visible: Environment.isDevelopment
           },
           {
-            role: 'toggledevtools',
-            visible: Environment.isDevelopment
-          },
-          {
             type: 'separator',
             visible: Environment.isDevelopment
           },


### PR DESCRIPTION
Since #124 we now have 2 identical devtools in dev mode.
Use the one in Help and remove the one in View.