### PR TITLE
feat(markdown): Add support for Wikilinks Syntax

### DIFF
--- a/src/renderer/utils/markdown.ts
+++ b/src/renderer/utils/markdown.ts
@@ -130,6 +130,41 @@ const Markdown = {
 
     },
 
+    // Wikilink
+    wikilink () {
+
+      const {path: notesPath} = Config.notes;
+
+      if ( !notesPath ) return [];
+
+      return [
+        { // Link
+          type: 'output',
+          regex: /\[{2}(.*?\|?.*?)\]{2}/g,
+          replace ( match, $1 ) {
+            const content  = $1
+            const splits = content.split("|"); 
+
+            if (splits.length === 1) {
+              const wikiLink = splits[0].trim();
+              const linkText = splits[0].trim();
+            }
+            else {
+              const wikiLink = splits[1].trim();
+              const linkText = splits[0].trim();
+            };
+
+            wikiLink = decodeURI ( wikiLink );
+            const basename = [wikiLink, 'md'].join('.'); // the extension should be configurable (= default extension)
+            const filePath = path.join ( notesPath, basename ); 
+            return `<a target="_blank" href="file://${filePath}" class="note" data-filepath="${filePath}"><i class="icon xsmall">note</i>${linkText}</a>`;
+          }
+        }
+      ];
+
+    },
+
+
     katex () {
 
       return showdownKatex ( Config.katex );
@@ -157,11 +192,11 @@ const Markdown = {
 
     if ( Markdown.converter ) return Markdown.converter;
 
-    const {encodeSpecialLinks, attachment, note, tag, katex, mermaid} = Markdown.extensions;
+    const {encodeSpecialLinks, attachment, note, tag, wikilink, katex, mermaid} = Markdown.extensions;
 
     const converter = new showdown.Converter ({
       metadata: true,
-      extensions: [showdownHighlight, showdownTargetBlack, encodeSpecialLinks (),attachment (), note (), tag (), katex (), mermaid ()]
+      extensions: [showdownHighlight, showdownTargetBlack, encodeSpecialLinks (),attachment (), note (), tag (), wikilink (), katex (), mermaid ()]
     });
 
     converter.setFlavor ( 'github' );

--- a/src/renderer/utils/markdown.ts
+++ b/src/renderer/utils/markdown.ts
@@ -215,7 +215,7 @@ const Markdown = {
 
     const converter = new showdown.Converter ({
       metadata: true,
-      extensions: [showdownTargetBlack, encodeSpecialLinks (),attachment (), note (), tag (), wikilink (), showdownHighlight, katex (), mermaid ()]
+      extensions: [showdownHighlight, showdownTargetBlack, encodeSpecialLinks (),attachment (), wikilink (), note (), tag (),  katex (), mermaid ()]
     });
 
     converter.setFlavor ( 'github' );

--- a/src/renderer/utils/markdown.ts
+++ b/src/renderer/utils/markdown.ts
@@ -168,8 +168,8 @@ const Markdown = {
                     wikiLink = decodeURI ( wikiLink );
                     var basename = [wikiLink, 'md'].join('.'); // the extension should be configurable (= default extension)
                     var filePath = path.join ( notesPath, basename ); 
-                    var link = `<a target="_blank" href="file://${filePath}" class="note" data-filepath="${filePath}"><i class="icon xsmall">note</i>${linkText}</a>`;
-                    
+                    // var link = `<a target="_blank" href="file://${filePath}" class="note" data-filepath="${filePath}"><i class="icon xsmall">note</i>${linkText}</a>`;
+                    var link = `<a href="@note/${basename}">${linkText}</a>`
                     // find placeholder and replace with link
                     var pat = '%PLACEHOLDER' + i + '%';
                     var text = text.replace(new RegExp(pat, 'gi'), link);

--- a/src/renderer/utils/markdown.ts
+++ b/src/renderer/utils/markdown.ts
@@ -138,8 +138,18 @@ const Markdown = {
       if ( !notesPath ) return [];
 
       var matches = [];
+      var codeblocks = [];
       return [
-        { // Link
+        { // Extract Codeblocks
+          type: 'lang',
+          regex: /((?:^|\n {0,3})(```+|~~~+)(?: *)([^\s`~]*)\n([\s\S]*?)\n(?: {0,3})\2)/g,
+          replace (match, $1) {
+            codeblocks.push($1);
+            var n = codeblocks.length - 1;
+            return '%CODEBLOCK' + n + '%';
+          }
+        },
+        { // Extract Wikilinks
           type: 'lang',
           regex: /(?<!`)\[\[(.*?)\]\]/g,
           replace (match, $1, $2) {
@@ -148,7 +158,15 @@ const Markdown = {
             return '%PLACEHOLDER' + n + '%';
           }
         },
-        {
+        { // Reinsert Codeblocks
+            type: 'lang',
+            regex: /%CODEBLOCK.*?%/gi,
+            replace (match) {
+                var codeblock = codeblocks.shift();
+                return codeblock;
+            }
+        },
+        { // Transform Wikilinks
           type: 'output',
           filter (text) {
                 for (var i=0; i< matches.length; ++i) {

--- a/src/renderer/utils/markdown.ts
+++ b/src/renderer/utils/markdown.ts
@@ -141,7 +141,7 @@ const Markdown = {
       return [
         { // Link
           type: 'lang',
-          regex: /(?<!```(?: *)(?:[^\s`~]*)\n(?:[\s\S]*?))\[{2}(.*?\|?.*?)\]{2}/g,
+          regex: /(?<!```(?: *)(?:[^\s`~]*)\n(?:[\s\S]*?)|`)\[{2}(.*?\|?.*?)\]{2}/g,
           replace (match, $1, $2) {
             matches.push($1);
             var n = matches.length - 1;

--- a/src/renderer/utils/markdown.ts
+++ b/src/renderer/utils/markdown.ts
@@ -141,7 +141,7 @@ const Markdown = {
       return [
         { // Link
           type: 'lang',
-          regex: /(?<!(?:^|\n)(?: {0,3})(?:```+|~~~+)(?: *)(?:[^\s`~]*)\n(?:[\s\S]*?)|`)\[{2}(.*?\|?.*?)\]{2}/g,
+          regex: /(?<!`)\[\[(.*?)\]\]/g,
           replace (match, $1, $2) {
             matches.push($1);
             var n = matches.length - 1;

--- a/src/renderer/utils/markdown.ts
+++ b/src/renderer/utils/markdown.ts
@@ -133,7 +133,7 @@ const Markdown = {
     // Wikilink
     wikilink () {
 
-      const {path: notesPath} = Config.notes;
+      const {path: notesPath, re} = Config.notes;
 
       if ( !notesPath ) return [];
 
@@ -166,10 +166,16 @@ const Markdown = {
                     };
 
                     wikiLink = decodeURI ( wikiLink );
-                    var basename = [wikiLink, 'md'].join('.'); // the extension should be configurable (= default extension)
+                    
+                    if (wikiLink.match(re)) {
+                      var basename = wikiLink; 
+                    } else {
+                      var basename = [wikiLink, 'md'].join('.'); // the extension should be configurable (= default extension)
+                    }
+
                     var filePath = path.join ( notesPath, basename ); 
-                    // var link = `<a target="_blank" href="file://${filePath}" class="note" data-filepath="${filePath}"><i class="icon xsmall">note</i>${linkText}</a>`;
                     var link = `<a href="@note/${basename}">${linkText}</a>`
+                    
                     // find placeholder and replace with link
                     var pat = '%PLACEHOLDER' + i + '%';
                     var text = text.replace(new RegExp(pat, 'gi'), link);

--- a/src/renderer/utils/markdown.ts
+++ b/src/renderer/utils/markdown.ts
@@ -141,7 +141,7 @@ const Markdown = {
       return [
         { // Link
           type: 'lang',
-          regex: /(?<!```(?: *)(?:[^\s`~]*)\n(?:[\s\S]*?)|`)\[{2}(.*?\|?.*?)\]{2}/g,
+          regex: /(?<!(?:^|\n)(?: {0,3})(?:```+|~~~+)(?: *)(?:[^\s`~]*)\n(?:[\s\S]*?)|`)\[{2}(.*?\|?.*?)\]{2}/g,
           replace (match, $1, $2) {
             matches.push($1);
             var n = matches.length - 1;


### PR DESCRIPTION
This adds rough support for Wikilink syntax.
Known limitation: Wikilinks in Code Blocks are also matched.