### PR TITLE
Adds install section to `README`

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,19 @@
 
 ---
 
+## Install
+
+There are a few ways to install Notable:
+
+- Download the app from [Notable.app](https://notable.app/#download).
+- Download from [GitHub Releases](https://github.com/notable/notable/releases).
+- Install via homebrew:
+  ```
+  brew install --cask notable
+  ```
+
+---
+
 I couldn't find a note-taking app that ticked all the boxes I'm interested in: notes are written and rendered in GitHub Flavored Markdown, no WYSIWYG, no proprietary formats, I can run a search & replace across all notes, notes support attachments, the app isn't bloated, the app has a pretty interface, tags are indefinitely nestable and can import Evernote notes (because that's what I was using before).
 
 So I built my own.


### PR DESCRIPTION
Very simply, adds a subheading in README top include ways to install Notable.

1. download from site
2. download from GH releases
3. using homebrew

Fixes #1473.